### PR TITLE
Python django-version-update

### DIFF
--- a/develop/develop/settings.py
+++ b/develop/develop/settings.py
@@ -76,20 +76,7 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'develop.wsgi.application'
 
-
-# Database
-# https://docs.djangoproject.com/en/2.1/ref/settings/#databases
-
-# DATABASES = {
-#     "default": {
-#         "ENGINE": "django.db.backends.postgresql_psycopg2",
-#         "NAME": os.getenv('PSQL_NAME', "reacttools"),
-#         "USER": os.getenv('PSQL_USER', "django"),
-#         "PASSWORD": os.getenv('PSQL_PASSWORD', "password"),
-#         "HOST": os.getenv('PSQL_HOST', "localhost"),
-#         "PORT": os.getenv('PSQL_PORT', ""),
-#     }
-# }
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
 DATABASES = {
     'default': {

--- a/reacttools/models.py
+++ b/reacttools/models.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
-from django.contrib.sites.models import Site
+from django.utils.translation import gettext_lazy as _
 from django.utils.text import slugify
 from django.templatetags.static import static
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(path.join(file_path, 'README.md'), encoding='utf-8') as f:
 
 package_metadata = {
     'name': 'django-react-tools',
-    'version': '0.2.13',
+    'version': '0.2.14',
     'description': 'Tools for helping integrate ReactJS into a Django project.',
     'long_description': long_description,
     'url': 'https://github.com/renderbox/django-react-tools',

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     packages=find_packages(),
     python_requires=">=3.6",
     install_requires=[
-        'Django>=2.1',
+        'Django>=2.1,<4.1',
         "requests",
         ],
     extras_require={


### PR DESCRIPTION
Note:

-  version bump 
-  changed ugettext_lazy with gettext_lazy as it was been deprecated for django 4.0 
-  added DEFAULT_AUTO_FIELD and removed commented code 
-  Made django version to be between 2.1 and 4.1

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>